### PR TITLE
Some servers returns 200 OK to Range: bytes=0-

### DIFF
--- a/httprs.go
+++ b/httprs.go
@@ -209,7 +209,12 @@ func (r *HttpReadSeeker) rangeRequest() error {
 	case http.StatusRequestedRangeNotSatisfiable:
 		return ErrInvalidRange
 	case http.StatusOK:
-		return ErrContentHasChanged
+		// some servers return 200 OK for bytes=0-
+		if r.pos > 0 ||
+			(etag != "" && etag != res.Header.Get("ETag")) {
+			return ErrContentHasChanged
+		}
+		fallthrough
 	case http.StatusPartialContent:
 		r.r = res.Body
 		return nil


### PR DESCRIPTION
Hello,
using `httprs` we discovered that some server implementations, namely Google Cloud Storage, downgrades `Range: bytes=0-` to normal GET requests without range.

Some more details can be found here https://gitlab.com/gitlab-org/gitlab-workhorse/issues/168

This patch prevents getting an `ErrContentHasChanged` on such situation.