### PR TITLE
Fix handling of Seek with SEEK_END

### DIFF
--- a/httprs.go
+++ b/httprs.go
@@ -149,7 +149,7 @@ func (r *HttpReadSeeker) Seek(offset int64, whence int) (int64, error) {
 		if r.res.ContentLength <= 0 {
 			return 0, ErrNoContentLength
 		}
-		offset = r.res.ContentLength - offset
+		offset = r.res.ContentLength + offset
 	}
 	if r.r != nil {
 		// Try to read, which is cheaper than doing a request

--- a/httprs_test.go
+++ b/httprs_test.go
@@ -198,7 +198,7 @@ func testHttpReaderSeeker(t *testing.T, newRS RSFactory) {
 			defer r.Close()
 			buf := make([]byte, 4)
 			io.ReadFull(r, buf)
-			s, err := r.Seek(4, os.SEEK_END)
+			s, err := r.Seek(-4, os.SEEK_END)
 			So(s, ShouldEqual, SZ*4-4)
 			So(err, ShouldBeNil)
 			n, err := io.ReadFull(r, buf)


### PR DESCRIPTION
This erroneously subtracted the offset from the content length instead of adding the offset as expected.

See also https://pkg.go.dev/io#Seeker (where `io.SeekEnd` is the same as `os.SEEK_END`):

> SeekEnd means relative to the end (for example, offset = -2 specifies the penultimate byte of the file).
